### PR TITLE
Add instructions for download.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 ledgersmb-installer - An installer for LedgerSMB, targetting as many platforms as possible
 on which the LedgerSMB server can run.
 
+The user instructions for downloading the most recent version of `ledgersmb-installer` are available at https://get.ledgersmb.org.
+
 # SYNOPSIS
 
 ```bash


### PR DESCRIPTION
When I first looked at the GitHub page, there were no releases and no instructions so I used git clone.

This should fix that problem in #10.